### PR TITLE
Delete CNAME to avoid problems when cloned

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-www.brycematheson.io


### PR DESCRIPTION
Currently, anyone who clones the project to use in a HUGO site, and host it in GitHub, he will recieve an annoying GitHub mail every thime a push is made, notifying that www.brycematheson.io is already taken.

This should avoid it ;)
